### PR TITLE
feat: allow toggling system proxy

### DIFF
--- a/src/assets/manifest.json
+++ b/src/assets/manifest.json
@@ -19,6 +19,7 @@
     "storage",
     "downloads",
     "tabs",
+    "proxy",
     "http://*/*",
     "https://*/*"
   ],

--- a/src/background/src/listeners/index.ts
+++ b/src/background/src/listeners/index.ts
@@ -1,8 +1,10 @@
 import { createStore } from "@hls-downloader/core/lib/store/configure-store";
 import { addPlaylistListener } from "./addPlaylistListener";
 import { setTabListener } from "./setTabListener";
+import { setProxyListener } from "./setProxyListener";
 
 export function subscribeListeners(store: ReturnType<typeof createStore>) {
   setTabListener(store);
   addPlaylistListener(store);
+  setProxyListener(store);
 }

--- a/src/background/src/listeners/setProxyListener.ts
+++ b/src/background/src/listeners/setProxyListener.ts
@@ -1,0 +1,27 @@
+import { createStore } from "@hls-downloader/core/lib/store/configure-store";
+import { proxy } from "webextension-polyfill";
+
+function applyProxy(enabled: boolean) {
+  if (!proxy?.settings?.set) {
+    return;
+  }
+  proxy.settings.set(
+    {
+      value: { mode: enabled ? "system" : "direct" },
+      scope: "regular",
+    },
+    () => {}
+  );
+}
+
+export function setProxyListener(store: ReturnType<typeof createStore>) {
+  let current = store.getState().config.proxyEnabled;
+  applyProxy(current);
+  store.subscribe(() => {
+    const next = store.getState().config.proxyEnabled;
+    if (next !== current) {
+      current = next;
+      applyProxy(next);
+    }
+  });
+}

--- a/src/background/test/setProxyListener.test.ts
+++ b/src/background/test/setProxyListener.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { configSlice } from "@hls-downloader/core/lib/store/slices";
+import { setProxyListener } from "../src/listeners/setProxyListener";
+import { proxy } from "webextension-polyfill";
+
+vi.mock("webextension-polyfill", () => ({
+  proxy: { settings: { set: vi.fn() } },
+}));
+
+describe("setProxyListener", () => {
+  it("updates proxy settings when toggled", () => {
+    let state = { config: { proxyEnabled: false } };
+    const listeners: Array<() => void> = [];
+    const store = {
+      getState: () => state,
+      subscribe: (fn: () => void) => {
+        listeners.push(fn);
+      },
+      dispatch: (action: any) => {
+        state = { config: configSlice.reducer(state.config, action) } as any;
+        listeners.forEach((fn) => fn());
+      },
+    } as any;
+    setProxyListener(store);
+    store.dispatch(
+      configSlice.actions.setProxyEnabled({ proxyEnabled: true })
+    );
+    expect(proxy.settings.set).toHaveBeenCalledWith(
+      { value: { mode: "system" }, scope: "regular" },
+      expect.any(Function)
+    );
+    store.dispatch(
+      configSlice.actions.setProxyEnabled({ proxyEnabled: false })
+    );
+    expect(proxy.settings.set).toHaveBeenCalledWith(
+      { value: { mode: "direct" }, scope: "regular" },
+      expect.any(Function)
+    );
+  });
+});

--- a/src/core/src/store/slices/config-slice.ts
+++ b/src/core/src/store/slices/config-slice.ts
@@ -16,10 +16,15 @@ export interface ISetFetchAttemptsPayload {
   fetchAttempts: number;
 }
 
+export interface ISetProxyEnabledPayload {
+  proxyEnabled: boolean;
+}
+
 export interface IConfigState {
   concurrency: number;
   saveDialog: boolean;
   fetchAttempts: number;
+  proxyEnabled: boolean;
 }
 
 interface IConfigReducers {
@@ -35,6 +40,10 @@ interface IConfigReducers {
     IConfigState,
     PayloadAction<ISetFetchAttemptsPayload>
   >;
+  setProxyEnabled: CaseReducer<
+    IConfigState,
+    PayloadAction<ISetProxyEnabledPayload>
+  >;
   [key: string]: CaseReducer<IConfigState, PayloadAction<any>>;
 }
 
@@ -42,6 +51,7 @@ const initialConfigState: IConfigState = {
   concurrency: 2,
   saveDialog: false,
   fetchAttempts: 100,
+  proxyEnabled: false,
 };
 
 export const configSlice: Slice<IConfigState, IConfigReducers, "config"> =
@@ -57,6 +67,9 @@ export const configSlice: Slice<IConfigState, IConfigReducers, "config"> =
       },
       setFetchAttempts(state, action: PayloadAction<ISetFetchAttemptsPayload>) {
         state.fetchAttempts = action.payload.fetchAttempts;
+      },
+      setProxyEnabled(state, action: PayloadAction<ISetProxyEnabledPayload>) {
+        state.proxyEnabled = action.payload.proxyEnabled;
       },
     },
   });

--- a/src/core/test/add-playlist-epic.test.ts
+++ b/src/core/test/add-playlist-epic.test.ts
@@ -14,7 +14,12 @@ describe("addPlaylistEpic", () => {
         playlistsStatus: {},
       },
       levels: { levels: {} },
-      config: { concurrency: 2, saveDialog: false, fetchAttempts: 1 },
+      config: {
+        concurrency: 2,
+        saveDialog: false,
+        fetchAttempts: 1,
+        proxyEnabled: false,
+      },
       tabs: { current: { id: -1 } },
       jobs: { jobs: {}, jobsStatus: {} },
     };

--- a/src/core/test/download-job-epic.test.ts
+++ b/src/core/test/download-job-epic.test.ts
@@ -28,7 +28,9 @@ describe("downloadJobEpic", () => {
     };
     const decryptor = { decrypt: vi.fn() };
     const action$ = of(jobsSlice.actions.add({ job }));
-    const state = { config: { concurrency: 1, fetchAttempts: 1 } };
+    const state = {
+      config: { concurrency: 1, fetchAttempts: 1, proxyEnabled: false },
+    };
     const result = await firstValueFrom(
       downloadJobEpic(
         action$,

--- a/src/core/test/save-as-job-epic.test.ts
+++ b/src/core/test/save-as-job-epic.test.ts
@@ -16,7 +16,7 @@ describe("saveAsJobEpic", () => {
     const action$ = of(jobsSlice.actions.saveAs({ jobId: "1" }));
     const state = {
       jobs: { jobs: { "1": job } },
-      config: { saveDialog: true },
+      config: { saveDialog: true, proxyEnabled: false },
     };
     const result = await firstValueFrom(
       saveAsJobEpic(action$, { value: state } as any, { fs } as any)

--- a/src/core/test/slices.test.ts
+++ b/src/core/test/slices.test.ts
@@ -26,6 +26,11 @@ describe("store slices", () => {
       configSlice.actions.setFetchAttempts({ fetchAttempts: 10 })
     );
     expect(state.fetchAttempts).toBe(10);
+    state = configSlice.reducer(
+      state,
+      configSlice.actions.setProxyEnabled({ proxyEnabled: true })
+    );
+    expect(state.proxyEnabled).toBe(true);
   });
 
   it("jobs slice reducers", () => {

--- a/src/core/test/test-utils.ts
+++ b/src/core/test/test-utils.ts
@@ -328,6 +328,7 @@ export function createMockState(
     concurrency = 2,
     fetchAttempts = 5,
     saveDialog = false,
+    proxyEnabled = false,
     tabId = 1,
   } = options;
 
@@ -347,6 +348,7 @@ export function createMockState(
       concurrency,
       fetchAttempts,
       saveDialog,
+      proxyEnabled,
     },
     tabs: {
       current: {

--- a/src/popup/src/modules/Settings/SettingsController.ts
+++ b/src/popup/src/modules/Settings/SettingsController.ts
@@ -6,9 +6,11 @@ interface ReturnType {
   concurrency: number;
   fetchAttempts: number;
   saveDialog: boolean;
+  proxyEnabled: boolean;
   onFetchAttemptsIncrease: () => void;
   onFetchAttemptsDecrease: () => void;
   onSaveDialogToggle: () => void;
+  onProxyToggle: () => void;
   onConcurrencyIncrease: () => void;
   onConcurrencyDecrease: () => void;
 }
@@ -23,6 +25,9 @@ const useSettingsController = (): ReturnType => {
   );
   const saveDialog = useSelector<RootState, boolean>(
     (state) => state.config.saveDialog
+  );
+  const proxyEnabled = useSelector<RootState, boolean>(
+    (state) => state.config.proxyEnabled
   );
 
   function onConcurrencyIncrease() {
@@ -60,15 +65,24 @@ const useSettingsController = (): ReturnType => {
       })
     );
   }
+  function onProxyToggle() {
+    dispatch(
+      configSlice.actions.setProxyEnabled({
+        proxyEnabled: !proxyEnabled,
+      })
+    );
+  }
   return {
     concurrency,
     onConcurrencyIncrease,
     onConcurrencyDecrease,
     fetchAttempts,
     saveDialog,
+    proxyEnabled,
     onFetchAttemptsIncrease,
     onFetchAttemptsDecrease,
     onSaveDialogToggle,
+    onProxyToggle,
   };
 };
 

--- a/src/popup/src/modules/Settings/SettingsModule.tsx
+++ b/src/popup/src/modules/Settings/SettingsModule.tsx
@@ -11,6 +11,8 @@ const SettingsModule = () => {
     fetchAttempts,
     onSaveDialogToggle,
     saveDialog,
+    proxyEnabled,
+    onProxyToggle,
     concurrency,
   } = useSettingsController();
 
@@ -21,6 +23,8 @@ const SettingsModule = () => {
       onFetchAttemptsIncrease={onFetchAttemptsIncrease}
       onSaveDialogToggle={onSaveDialogToggle}
       saveDialog={saveDialog}
+      proxyEnabled={proxyEnabled}
+      onProxyToggle={onProxyToggle}
       onConcurrencyDecrease={onConcurrencyDecrease}
       onConcurrencyIncrease={onConcurrencyIncrease}
       concurrency={concurrency}

--- a/src/popup/src/modules/Settings/SettingsView.stories.tsx
+++ b/src/popup/src/modules/Settings/SettingsView.stories.tsx
@@ -15,11 +15,13 @@ export const Default: Story = {
       concurrency={3}
       fetchAttempts={5}
       saveDialog={true}
+      proxyEnabled={true}
       onConcurrencyIncrease={() => {}}
       onConcurrencyDecrease={() => {}}
       onFetchAttemptsIncrease={() => {}}
       onFetchAttemptsDecrease={() => {}}
       onSaveDialogToggle={() => {}}
+      onProxyToggle={() => {}}
     />
   ),
 };
@@ -30,11 +32,13 @@ export const Minimal: Story = {
       concurrency={1}
       fetchAttempts={1}
       saveDialog={false}
+      proxyEnabled={false}
       onConcurrencyIncrease={() => {}}
       onConcurrencyDecrease={() => {}}
       onFetchAttemptsIncrease={() => {}}
       onFetchAttemptsDecrease={() => {}}
       onSaveDialogToggle={() => {}}
+      onProxyToggle={() => {}}
     />
   ),
 };

--- a/src/popup/src/modules/Settings/SettingsView.tsx
+++ b/src/popup/src/modules/Settings/SettingsView.tsx
@@ -5,9 +5,11 @@ interface Props {
   concurrency: number;
   fetchAttempts: number;
   saveDialog: boolean;
+  proxyEnabled: boolean;
   onFetchAttemptsIncrease: () => void;
   onFetchAttemptsDecrease: () => void;
   onSaveDialogToggle: () => void;
+  onProxyToggle: () => void;
   onConcurrencyIncrease: () => void;
   onConcurrencyDecrease: () => void;
 }
@@ -16,11 +18,13 @@ const SettingsView = ({
   concurrency,
   fetchAttempts,
   saveDialog,
+  proxyEnabled,
   onConcurrencyIncrease,
   onConcurrencyDecrease,
   onFetchAttemptsIncrease,
   onFetchAttemptsDecrease,
   onSaveDialogToggle,
+  onProxyToggle,
 }: Props) => {
   return (
     <div className="flex flex-col p-4 space-y-4">
@@ -82,6 +86,15 @@ const SettingsView = ({
             aria-label="toggle save dialog"
             onClick={onSaveDialogToggle}
             checked={saveDialog}
+          ></Switch>
+        </div>
+
+        <div className="flex items-center justify-between rounded-lg border p-3">
+          <p className="text-sm font-medium">System Proxy</p>
+          <Switch
+            aria-label="toggle system proxy"
+            onClick={onProxyToggle}
+            checked={proxyEnabled}
           ></Switch>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `proxyEnabled` option to config slice
- add switch on Settings page to toggle system proxy
- apply proxy settings in background and request `proxy` permission

## Testing
- `pnpm test:core`
- `pnpm test:background`
- `pnpm test:popup`

---

close #460 