### PR TITLE
Add sniffer video preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev:background": "pnpm --filter ./src/background run dev",
     "dev:popup": "pnpm --filter ./src/popup run dev",
     "predev": "pnpm run clean && pnpm run copy-assets",
-    "dev": "run-p dev:*",
+    "dev": "DIST_DIR=dist/mv3 MV_TARGET=mv3 run-p dev:*",
     "test": "run-p test:core test:background test:design-system test:popup",
     "test:core": "pnpm --filter ./src/core run test",
     "test:background": "pnpm --filter ./src/background run test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       gsap:
         specifier: ^3.13.0
         version: 3.13.0
+      hls.js:
+        specifier: ^1.6.15
+        version: 1.6.15
       lucide-react:
         specifier: ^0.137.0
         version: 0.137.0(react@18.3.1)
@@ -2591,6 +2594,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  hls.js@1.6.15:
+    resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -6479,6 +6485,8 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  hls.js@1.6.15: {}
 
   hoist-non-react-statics@3.3.2:
     dependencies:

--- a/src/popup/package.json
+++ b/src/popup/package.json
@@ -6,6 +6,7 @@
     "@hls-downloader/core": "workspace:*",
     "@hls-downloader/design-system": "workspace:*",
     "gsap": "^3.13.0",
+    "hls.js": "^1.6.15",
     "lucide-react": "^0.137.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/src/popup/src/modules/Sniffer/PlaylistPreview.tsx
+++ b/src/popup/src/modules/Sniffer/PlaylistPreview.tsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Playlist, PlaylistStatus } from "@hls-downloader/core/lib/entities";
+import { AspectRatio, Button, Card } from "@hls-downloader/design-system";
+import Hls from "hls.js";
+import { AlertTriangle, Loader2, RefreshCcw } from "lucide-react";
+
+type PreviewState = "idle" | "loading" | "ready" | "error";
+
+interface Props {
+  playlist: Playlist;
+  status?: PlaylistStatus | null;
+}
+
+const PlaylistPreview = ({ playlist, status }: Props) => {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const hlsRef = useRef<Hls | null>(null);
+  const [state, setState] = useState<PreviewState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    let cancelled = false;
+    const teardown = () => {
+      const instance = hlsRef.current;
+      if (instance) {
+        instance.destroy();
+        hlsRef.current = null;
+      }
+      video.pause();
+      video.removeAttribute("src");
+      video.load();
+    };
+
+    teardown();
+
+    if (!playlist?.uri) {
+      setState("idle");
+      setError(null);
+      return;
+    }
+
+    setState("loading");
+    setError(null);
+
+    const onReady = () => {
+      if (cancelled) return;
+      setState("ready");
+    };
+    const onVideoError = () => {
+      if (cancelled) return;
+      teardown();
+      setState("error");
+      setError("Preview failed to load.");
+    };
+
+    if (video.canPlayType("application/vnd.apple.mpegurl")) {
+      video.addEventListener("loadedmetadata", onReady);
+      video.addEventListener("error", onVideoError);
+      video.src = playlist.uri;
+      video.load();
+    } else if (Hls.isSupported()) {
+      const hls = new Hls({
+        enableWorker: true,
+        backBufferLength: 120,
+      });
+      hlsRef.current = hls;
+      hls.on(Hls.Events.MANIFEST_PARSED, onReady);
+      hls.on(Hls.Events.ERROR, (_event, data) => {
+        if (cancelled) return;
+        if (data?.fatal) {
+          teardown();
+          setState("error");
+          setError("Preview failed to load.");
+        }
+      });
+      hls.attachMedia(video);
+      hls.loadSource(playlist.uri);
+    } else {
+      setState("error");
+      setError("HLS preview is not supported in this browser.");
+    }
+
+    return () => {
+      cancelled = true;
+      video.removeEventListener("loadedmetadata", onReady);
+      video.removeEventListener("error", onVideoError);
+      teardown();
+    };
+  }, [playlist?.id, playlist?.uri, reloadKey]);
+
+  useEffect(
+    () => () => {
+      const video = videoRef.current;
+      if (video) {
+        video.pause();
+        video.removeAttribute("src");
+        video.load();
+      }
+      const instance = hlsRef.current;
+      if (instance) {
+        instance.destroy();
+        hlsRef.current = null;
+      }
+    },
+    []
+  );
+
+  const statusHint =
+    status?.status === "fetching"
+      ? "Sniffing playlist..."
+      : status?.status === "error"
+        ? "Playlist may not be playable yet."
+        : null;
+
+  const statusLabel =
+    state === "loading"
+      ? "Loading preview..."
+      : state === "ready"
+        ? "Preview ready"
+        : state === "error"
+          ? "Preview unavailable"
+          : "Preview";
+
+  return (
+    <Card className="p-3 space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-sm font-semibold">Preview</div>
+        <div className="text-[11px] text-muted-foreground">{statusLabel}</div>
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={() => setReloadKey((key) => key + 1)}
+          disabled={state === "loading"}
+          aria-label="Reload preview"
+        >
+          <RefreshCcw className="h-4 w-4" />
+        </Button>
+      </div>
+      <AspectRatio
+        ratio={16 / 9}
+        className="relative overflow-hidden rounded-md bg-muted"
+      >
+        <video
+          ref={videoRef}
+          className="absolute inset-0 h-full w-full object-cover"
+          controls
+          muted
+          playsInline
+        />
+        {state === "loading" && (
+          <div className="absolute inset-0 flex items-center justify-center bg-background/70">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+        {state === "error" && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-background/80 px-4 text-center">
+            <AlertTriangle className="h-5 w-5 text-muted-foreground" />
+            <p className="text-xs text-muted-foreground">
+              {error ?? "Preview unavailable"}
+            </p>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => setReloadKey((key) => key + 1)}
+              disabled={state === "loading"}
+            >
+              Try again
+            </Button>
+          </div>
+        )}
+      </AspectRatio>
+      {statusHint && (
+        <div className="text-[11px] text-muted-foreground">{statusHint}</div>
+      )}
+    </Card>
+  );
+};
+
+export default PlaylistPreview;

--- a/src/popup/src/modules/Sniffer/SnifferController.ts
+++ b/src/popup/src/modules/Sniffer/SnifferController.ts
@@ -10,6 +10,8 @@ import { useDispatch, useSelector } from "react-redux";
 interface ReturnType {
   playlists: Playlist[];
   currentPlaylistId: string | undefined;
+  currentPlaylist: Playlist | null;
+  currentPlaylistStatus: PlaylistStatus | null;
   filter: string;
   clearPlaylists: () => void;
   setFilter: (filter: string) => void;
@@ -103,6 +105,12 @@ const useSnifferController = (): ReturnType => {
   }
 
   return {
+    currentPlaylist: currentPlaylistId
+      ? playlistsRecord[currentPlaylistId] ?? null
+      : null,
+    currentPlaylistStatus: currentPlaylistId
+      ? playlistsStatusRecord[currentPlaylistId] ?? null
+      : null,
     filter,
     clearPlaylists,
     setFilter,

--- a/src/popup/src/modules/Sniffer/SnifferModule.tsx
+++ b/src/popup/src/modules/Sniffer/SnifferModule.tsx
@@ -9,6 +9,8 @@ const SnifferModule = () => {
     filter,
     setCurrentPlaylistId,
     playlists,
+    currentPlaylist,
+    currentPlaylistStatus,
     currentPlaylistId,
     copyPlaylistsToClipboard,
     directURI,
@@ -26,6 +28,8 @@ const SnifferModule = () => {
       setFilter={setFilter}
       setCurrentPlaylistId={setCurrentPlaylistId}
       playlists={playlists}
+      currentPlaylist={currentPlaylist}
+      currentPlaylistStatus={currentPlaylistStatus}
       currentPlaylistId={currentPlaylistId}
       directURI={directURI}
       setDirectURI={setDirectURI}

--- a/src/popup/src/modules/Sniffer/SnifferView.stories.tsx
+++ b/src/popup/src/modules/Sniffer/SnifferView.stories.tsx
@@ -88,6 +88,8 @@ export const Selected: Story = {
     <SnifferView
       playlists={samplePlaylists}
       currentPlaylistId="1"
+      currentPlaylist={samplePlaylists[0]}
+      currentPlaylistStatus={{ status: "ready" }}
       filter=""
       clearPlaylists={() => {}}
       setFilter={() => {}}
@@ -150,6 +152,8 @@ export const TransitionDemo: Story = {
     const [directURI, setDirectURI] = useState("");
 
     const playlists = samplePlaylists;
+    const currentPlaylist =
+      playlists.find((p) => p.id === currentPlaylistId) ?? null;
     const toggleExpandedPlaylist = (id: string) => {
       setExpandedPlaylists((prev) =>
         prev.includes(id) ? prev.filter((pid) => pid !== id) : [...prev, id]
@@ -160,6 +164,10 @@ export const TransitionDemo: Story = {
       <SnifferView
         playlists={playlists}
         currentPlaylistId={currentPlaylistId}
+        currentPlaylist={currentPlaylist}
+        currentPlaylistStatus={
+          currentPlaylistId ? { status: "ready" } : undefined
+        }
         filter={filter}
         clearPlaylists={() => {
           setCurrentPlaylistId(undefined);

--- a/src/popup/src/modules/Sniffer/SnifferView.tsx
+++ b/src/popup/src/modules/Sniffer/SnifferView.tsx
@@ -1,4 +1,4 @@
-import { Playlist } from "@hls-downloader/core/lib/entities";
+import { Playlist, PlaylistStatus } from "@hls-downloader/core/lib/entities";
 import {
   Button,
   Input,
@@ -17,10 +17,13 @@ import {
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import gsap from "gsap";
 import PlaylistModule from "../Playlist/PlaylistModule";
+import PlaylistPreview from "./PlaylistPreview";
 
 interface Props {
   playlists: Playlist[];
   currentPlaylistId: string | undefined;
+  currentPlaylist?: Playlist | null;
+  currentPlaylistStatus?: PlaylistStatus | null;
   filter: string;
   clearPlaylists: () => void;
   copyPlaylistsToClipboard: () => void;
@@ -40,6 +43,8 @@ const SnifferView = ({
   filter,
   playlists,
   currentPlaylistId,
+  currentPlaylist,
+  currentPlaylistStatus,
   setCurrentPlaylistId,
   directURI,
   setDirectURI,
@@ -130,6 +135,12 @@ const SnifferView = ({
           >
             Back
           </Button>
+        )}
+        {visibleDetailId && currentPlaylist && (
+          <PlaylistPreview
+            playlist={currentPlaylist}
+            status={currentPlaylistStatus}
+          />
         )}
         {visibleDetailId && <PlaylistModule id={visibleDetailId} />}
       </div>


### PR DESCRIPTION
## Summary
- add an HLS.js-powered preview player to the sniffer detail view so users can verify streams before downloading
- surface playlist metadata/status in the view and keep preview/reload UX light with loading/error overlays
- wire storybook/demo coverage and bring in hls.js dependency for the popup package

## Testing
- pnpm --filter ./src/popup test

Closes #483
