### PR TITLE
fix: white text on white background in native selects with Firefox dark theme

### DIFF
--- a/src/popup/src/modules/Playlist/PlaylistView.tsx
+++ b/src/popup/src/modules/Playlist/PlaylistView.tsx
@@ -218,7 +218,7 @@ const PlaylistView = ({
                   </div>
                   <div className="flex-1 min-w-[200px] border rounded-md">
                     <select
-                      className="w-full p-2 text-sm bg-transparent border-r-8 border-r-transparent"
+                      className="w-full p-2 text-sm bg-background text-foreground border-r-8 border-r-transparent"
                       value={selectedVideoId ?? ""}
                       onChange={(e) => handleSelectVideo(e.target.value)}
                     >
@@ -272,7 +272,7 @@ const PlaylistView = ({
                   </div>
                   <div className="flex-1 min-w-[200px] border rounded-md">
                     <select
-                      className="w-full p-2 text-sm bg-transparent border-r-8 border-r-transparent"
+                      className="w-full p-2 text-sm bg-background text-foreground border-r-8 border-r-transparent"
                       value={selectedAudioId ?? ""}
                       onChange={(e) => handleSelectAudio(e.target.value)}
                     >
@@ -326,7 +326,7 @@ const PlaylistView = ({
                   </div>
                   <div className="flex-1 min-w-[200px] border rounded-md">
                     <select
-                      className="w-full p-2 text-sm bg-transparent border-r-8 border-r-transparent"
+                      className="w-full p-2 text-sm bg-background text-foreground border-r-8 border-r-transparent"
                       value={selectedSubtitleId ?? ""}
                       onChange={(e) => onSelectSubtitle(e.target.value)}
                     >

--- a/src/popup/src/modules/Settings/SettingsView.tsx
+++ b/src/popup/src/modules/Settings/SettingsView.tsx
@@ -227,7 +227,7 @@ const SettingsView = ({
           </div>
           <div className="flex-1 min-w-[240px] border rounded-md">
             <select
-              className="w-full p-2 text-sm bg-transparent border-r-8 border-r-transparent"
+              className="w-full p-2 text-sm bg-background text-foreground border-r-8 border-r-transparent"
               value={preferredAudioLanguage ?? ""}
               onChange={(e) =>
                 onSetPreferredAudioLanguage(e.target.value || null)


### PR DESCRIPTION
## Summary
- Native `<select>` elements used `bg-transparent` with no explicit text color, causing white text on white background when Firefox's dark theme is active
- Added `bg-background text-foreground` classes to all 4 native `<select>` elements so they use the extension's CSS theme variables instead of browser defaults
- Affects video quality, audio track, subtitle selects in PlaylistView and preferred audio language select in SettingsView

## Test plan
- [ ] Load extension in Firefox with dark theme enabled
- [ ] Verify video/audio/subtitle dropdowns are readable on a page with HLS content
- [ ] Verify Settings page preferred audio language dropdown is readable
- [ ] Verify light theme still looks correct

Closes #487