### PR TITLE
fix: sanitize download filenames to remove illegal characters

### DIFF
--- a/src/core/src/use-cases/generate-file-name.ts
+++ b/src/core/src/use-cases/generate-file-name.ts
@@ -1,4 +1,5 @@
 import { Playlist, Level } from "../entities";
+import { sanitizeFilename } from "./sanitize-filename";
 
 type GenerateFileNameOptions = {
   container?: "mp4" | "mkv";
@@ -17,7 +18,7 @@ export const generateFileName = () => {
     const container = options?.container ?? "mp4";
 
     const filename = playlist.pageTitle
-      ? `${playlist.pageTitle}-${playlistFilenameWithoutExt}.${container}`
+      ? `${sanitizeFilename(playlist.pageTitle)}-${playlistFilenameWithoutExt}.${container}`
       : `${playlistFilenameWithoutExt}.${container}`;
 
     return filename.normalize("NFC");

--- a/src/core/src/use-cases/generate-subtitle-file-name.ts
+++ b/src/core/src/use-cases/generate-subtitle-file-name.ts
@@ -1,10 +1,11 @@
 import { Level, Playlist } from "../entities";
+import { sanitizeFilename } from "./sanitize-filename";
 
 export const generateSubtitleFileName = () => {
   const run = (playlist: Playlist, level: Level): string => {
     const baseTitle =
       playlist.pageTitle && playlist.pageTitle.trim().length > 0
-        ? playlist.pageTitle
+        ? sanitizeFilename(playlist.pageTitle)
         : "subtitle";
 
     const language = level.language || level.name || level.id || "track";

--- a/src/core/src/use-cases/sanitize-filename.ts
+++ b/src/core/src/use-cases/sanitize-filename.ts
@@ -1,0 +1,6 @@
+export function sanitizeFilename(name: string): string {
+  return name
+    .replace(/[<>:"/\\|?*]/g, "_")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/src/core/test/use-cases.test.ts
+++ b/src/core/test/use-cases.test.ts
@@ -7,6 +7,7 @@ import {
   fsCleanupFactory,
   getLinkBucketFactory,
   generateFileName,
+  generateSubtitleFileName,
   decryptSingleFragmentFactory,
   downloadSingleFactory,
   getFragmentsDetailsFactory,
@@ -93,6 +94,30 @@ describe("use-cases", () => {
     const level = new Level("stream", "l", "1", "uri");
     const run = generateFileName();
     expect(run(playlist, level)).toBe("page-c.mp4");
+  });
+
+  it("sanitizes illegal characters in page title", () => {
+    const playlist = new Playlist(
+      "1",
+      "https://a/b/stream.m3u8",
+      Date.now(),
+      'Video "Test" <2024>'
+    );
+    const level = new Level("stream", "l", "1", "uri");
+    const run = generateFileName();
+    expect(run(playlist, level)).toBe("Video _Test_ _2024_-stream.mp4");
+  });
+
+  it("sanitizes illegal characters in subtitle page title", () => {
+    const playlist = new Playlist(
+      "1",
+      "https://a/b/stream.m3u8",
+      Date.now(),
+      'Video "Test" <2024>'
+    );
+    const level = new Level("subtitle", "English", "1", "uri", undefined, undefined, undefined, undefined, "en");
+    const run = generateSubtitleFileName();
+    expect(run(playlist, level)).toBe("Video _Test_ _2024_-en.vtt");
   });
 
   it("normalizes non-ASCII page title", () => {


### PR DESCRIPTION
## Summary
- Adds a `sanitizeFilename` helper that replaces Windows-illegal characters (`<>:"/\|?*`) with underscores
- Applies sanitization to page titles in both `generateFileName` and `generateSubtitleFileName`
- Fixes downloads failing when page titles contain special characters (closes #491)

## Test plan
- [x] Added test: filename with illegal chars gets sanitized
- [x] Added test: subtitle filename with illegal chars gets sanitized
- [x] All 27 existing + new tests pass