### PR TITLE
feat: add auto delete after save option

### DIFF
--- a/src/core/src/controllers/auto-delete-after-save-epic.ts
+++ b/src/core/src/controllers/auto-delete-after-save-epic.ts
@@ -1,0 +1,19 @@
+import { Epic } from "redux-observable";
+import { filter, map } from "rxjs/operators";
+import { RootAction, RootState } from "../store/root-reducer";
+import { jobsSlice } from "../store/slices";
+import { Dependencies } from "../services";
+
+export const autoDeleteAfterSaveEpic: Epic<
+  RootAction,
+  RootAction,
+  RootState,
+  Dependencies
+> = (action$, store$) =>
+  action$.pipe(
+    filter(jobsSlice.actions.saveAsSuccess.match),
+    filter(() => store$.value.config.autoDeleteAfterSave),
+    map((action) =>
+      jobsSlice.actions.delete({ jobId: action.payload.jobId })
+    )
+  );

--- a/src/core/src/controllers/index.ts
+++ b/src/core/src/controllers/index.ts
@@ -13,3 +13,4 @@ export * from "./inspect-level-epic";
 export * from "./remove-playlist-epic";
 export * from "./storage-epics";
 export * from "./fetch-level-duration-epic";
+export * from "./auto-delete-after-save-epic";

--- a/src/core/src/store/slices/config-slice.ts
+++ b/src/core/src/store/slices/config-slice.ts
@@ -24,12 +24,17 @@ export interface ISetMaxActiveDownloadsPayload {
   maxActiveDownloads: number;
 }
 
+export interface ISetAutoDeleteAfterSavePayload {
+  autoDeleteAfterSave: boolean;
+}
+
 export interface IConfigState {
   concurrency: number;
   saveDialog: boolean;
   fetchAttempts: number;
   preferredAudioLanguage: string | null;
   maxActiveDownloads: number;
+  autoDeleteAfterSave: boolean;
 }
 
 interface IConfigReducers {
@@ -53,6 +58,10 @@ interface IConfigReducers {
     IConfigState,
     PayloadAction<ISetMaxActiveDownloadsPayload>
   >;
+  setAutoDeleteAfterSave: CaseReducer<
+    IConfigState,
+    PayloadAction<ISetAutoDeleteAfterSavePayload>
+  >;
   [key: string]: CaseReducer<IConfigState, PayloadAction<any>>;
 }
 
@@ -62,6 +71,7 @@ export const initialConfigState: IConfigState = {
   fetchAttempts: 100,
   preferredAudioLanguage: null,
   maxActiveDownloads: 0,
+  autoDeleteAfterSave: false,
 };
 
 export const configSlice: Slice<IConfigState, IConfigReducers, "config"> =
@@ -89,6 +99,12 @@ export const configSlice: Slice<IConfigState, IConfigReducers, "config"> =
         action: PayloadAction<ISetMaxActiveDownloadsPayload>
       ) {
         state.maxActiveDownloads = action.payload.maxActiveDownloads;
+      },
+      setAutoDeleteAfterSave(
+        state,
+        action: PayloadAction<ISetAutoDeleteAfterSavePayload>
+      ) {
+        state.autoDeleteAfterSave = action.payload.autoDeleteAfterSave;
       },
     },
   });

--- a/src/popup/src/modules/Settings/SettingsController.ts
+++ b/src/popup/src/modules/Settings/SettingsController.ts
@@ -7,9 +7,11 @@ interface ReturnType {
   maxActiveDownloads: number;
   fetchAttempts: number;
   saveDialog: boolean;
+  autoDeleteAfterSave: boolean;
   onFetchAttemptsIncrease: () => void;
   onFetchAttemptsDecrease: () => void;
   onSaveDialogToggle: () => void;
+  onAutoDeleteAfterSaveToggle: () => void;
   onConcurrencyIncrease: () => void;
   onConcurrencyDecrease: () => void;
   onActiveDownloadsIncrease: () => void;
@@ -36,6 +38,9 @@ const useSettingsController = (): ReturnType => {
   );
   const preferredAudioLanguage = useSelector<RootState, string | null>(
     (state) => state.config.preferredAudioLanguage
+  );
+  const autoDeleteAfterSave = useSelector<RootState, boolean>(
+    (state) => state.config.autoDeleteAfterSave
   );
   const activeDownloadsUnlimited = maxActiveDownloads === 0;
 
@@ -97,6 +102,13 @@ const useSettingsController = (): ReturnType => {
       })
     );
   }
+  function onAutoDeleteAfterSaveToggle() {
+    dispatch(
+      configSlice.actions.setAutoDeleteAfterSave({
+        autoDeleteAfterSave: !autoDeleteAfterSave,
+      })
+    );
+  }
   function onSetPreferredAudioLanguage(lang: string | null) {
     const normalized = (lang ?? "").trim();
     dispatch(
@@ -116,9 +128,11 @@ const useSettingsController = (): ReturnType => {
     onActiveDownloadsUnlimited,
     fetchAttempts,
     saveDialog,
+    autoDeleteAfterSave,
     onFetchAttemptsIncrease,
     onFetchAttemptsDecrease,
     onSaveDialogToggle,
+    onAutoDeleteAfterSaveToggle,
     preferredAudioLanguage,
     onSetPreferredAudioLanguage,
   };

--- a/src/popup/src/modules/Settings/SettingsModule.tsx
+++ b/src/popup/src/modules/Settings/SettingsModule.tsx
@@ -11,7 +11,9 @@ const SettingsModule = () => {
     onFetchAttemptsIncrease,
     fetchAttempts,
     onSaveDialogToggle,
+    onAutoDeleteAfterSaveToggle,
     saveDialog,
+    autoDeleteAfterSave,
     concurrency,
     preferredAudioLanguage,
     onSetPreferredAudioLanguage,
@@ -29,7 +31,9 @@ const SettingsModule = () => {
       onFetchAttemptsDecrease={onFetchAttemptsDecrease}
       onFetchAttemptsIncrease={onFetchAttemptsIncrease}
       onSaveDialogToggle={onSaveDialogToggle}
+      onAutoDeleteAfterSaveToggle={onAutoDeleteAfterSaveToggle}
       saveDialog={saveDialog}
+      autoDeleteAfterSave={autoDeleteAfterSave}
       onConcurrencyDecrease={onConcurrencyDecrease}
       onConcurrencyIncrease={onConcurrencyIncrease}
       concurrency={concurrency}

--- a/src/popup/src/modules/Settings/SettingsView.stories.tsx
+++ b/src/popup/src/modules/Settings/SettingsView.stories.tsx
@@ -17,6 +17,7 @@ export const Default: Story = {
       activeDownloadsUnlimited={false}
       fetchAttempts={5}
       saveDialog={true}
+      autoDeleteAfterSave={false}
       onConcurrencyIncrease={() => {}}
       onConcurrencyDecrease={() => {}}
       onActiveDownloadsIncrease={() => {}}
@@ -25,6 +26,7 @@ export const Default: Story = {
       onFetchAttemptsIncrease={() => {}}
       onFetchAttemptsDecrease={() => {}}
       onSaveDialogToggle={() => {}}
+      onAutoDeleteAfterSaveToggle={() => {}}
       preferredAudioLanguage={"eng"}
       onSetPreferredAudioLanguage={() => {}}
     />
@@ -39,6 +41,7 @@ export const Minimal: Story = {
       activeDownloadsUnlimited={true}
       fetchAttempts={1}
       saveDialog={false}
+      autoDeleteAfterSave={true}
       onConcurrencyIncrease={() => {}}
       onConcurrencyDecrease={() => {}}
       onActiveDownloadsIncrease={() => {}}
@@ -47,6 +50,7 @@ export const Minimal: Story = {
       onFetchAttemptsIncrease={() => {}}
       onFetchAttemptsDecrease={() => {}}
       onSaveDialogToggle={() => {}}
+      onAutoDeleteAfterSaveToggle={() => {}}
       preferredAudioLanguage={null}
       onSetPreferredAudioLanguage={() => {}}
     />

--- a/src/popup/src/modules/Settings/SettingsView.tsx
+++ b/src/popup/src/modules/Settings/SettingsView.tsx
@@ -9,9 +9,11 @@ interface Props {
   activeDownloadsUnlimited: boolean;
   fetchAttempts: number;
   saveDialog: boolean;
+  autoDeleteAfterSave: boolean;
   onFetchAttemptsIncrease: () => void;
   onFetchAttemptsDecrease: () => void;
   onSaveDialogToggle: () => void;
+  onAutoDeleteAfterSaveToggle: () => void;
   onConcurrencyIncrease: () => void;
   onConcurrencyDecrease: () => void;
   onActiveDownloadsIncrease: () => void;
@@ -60,6 +62,7 @@ const SettingsView = ({
   concurrency,
   fetchAttempts,
   saveDialog,
+  autoDeleteAfterSave,
   onConcurrencyIncrease,
   onConcurrencyDecrease,
   onActiveDownloadsIncrease,
@@ -70,6 +73,7 @@ const SettingsView = ({
   onFetchAttemptsIncrease,
   onFetchAttemptsDecrease,
   onSaveDialogToggle,
+  onAutoDeleteAfterSaveToggle,
   preferredAudioLanguage = "",
   onSetPreferredAudioLanguage,
   storage,
@@ -215,6 +219,20 @@ const SettingsView = ({
             aria-label="toggle save dialog"
             onClick={onSaveDialogToggle}
             checked={saveDialog}
+          ></Switch>
+        </Card>
+
+        <Card className="flex-row items-center justify-between gap-2">
+          <div className="flex flex-col">
+            <p className="text-sm font-medium">Auto delete after save</p>
+            <p className="text-[11px] text-muted-foreground">
+              Remove downloaded data after saving
+            </p>
+          </div>
+          <Switch
+            aria-label="toggle auto delete after save"
+            onClick={onAutoDeleteAfterSaveToggle}
+            checked={autoDeleteAfterSave}
           ></Switch>
         </Card>
 


### PR DESCRIPTION
## Summary
- Adds an opt-in "Auto delete after save" toggle in Settings
- When enabled, IndexedDB data is automatically cleaned up after a successful save (mux + download)
- Frees storage without requiring manual job deletion

## Test plan
- [ ] Load extension, go to Settings, verify new toggle appears after "Save dialog"
- [ ] Toggle on, download an HLS stream, click Save — job should be removed after save completes
- [ ] Toggle off, repeat — job should remain in "done" state after save