### PR TITLE
fix: preserve embedded audio in muxed HLS streams

### DIFF
--- a/src/background/src/services/ffmpeg-muxer.ts
+++ b/src/background/src/services/ffmpeg-muxer.ts
@@ -62,9 +62,10 @@ export async function muxStreams({
     }
     args.push("-c:v", "copy", "-c:a", "copy", "-bsf:a", "aac_adtstoasc");
   } else if (hasVideo) {
-    args.push("-map", "0:v:0", "-c:v", "copy");
+    // Map all streams from the video file (preserves embedded audio)
+    args.push("-map", "0", "-c", "copy");
     if (includeSubtitles) {
-      args.push("-map", `${hasAudio ? "2" : "1"}:s:0`);
+      args.push("-map", "1:s:0", "-c:s", "webvtt");
     }
   } else if (hasAudio) {
     args.push(


### PR DESCRIPTION
## Summary
- Fixed issue where downloading HLS streams with muxed audio+video (no separate audio playlist) resulted in video without sound
- Changed ffmpeg muxer to use `-map 0 -c copy` instead of `-map 0:v:0 -c:v copy` in the video-only branch, preserving all embedded streams including audio

## Test plan
- [ ] Build the extension and test with an HLS stream that has muxed audio+video (no separate audio playlist) — the downloaded file should contain audio
- [ ] Test with separate video+audio streams — should still work as before (the `hasVideo && hasAudio` branch is unchanged)
- [ ] Test subtitle inclusion in both scenarios

Closes #489