### PR TITLE
Add sniffer playlist removal

### DIFF
--- a/src/popup/src/modules/Sniffer/SnifferController.ts
+++ b/src/popup/src/modules/Sniffer/SnifferController.ts
@@ -12,6 +12,7 @@ interface ReturnType {
   currentPlaylistId: string | undefined;
   filter: string;
   clearPlaylists: () => void;
+  removePlaylist: (playlistId: string) => void;
   setFilter: (filter: string) => void;
   setCurrentPlaylistId: (playlistId?: string) => void;
   copyPlaylistsToClipboard: () => void;
@@ -67,6 +68,14 @@ const useSnifferController = (): ReturnType => {
     dispatch(playlistsSlice.actions.clearPlaylists());
   }
 
+  function removePlaylist(playlistId: string) {
+    dispatch(playlistsSlice.actions.removePlaylist({ playlistID: playlistId }));
+    setExpandedPlaylists((prev) => prev.filter((id) => id !== playlistId));
+    if (currentPlaylistId === playlistId) {
+      setCurrentPlaylistId(undefined);
+    }
+  }
+
   function addDirectPlaylist() {
     if (!directURI) return;
     dispatch(
@@ -105,6 +114,7 @@ const useSnifferController = (): ReturnType => {
   return {
     filter,
     clearPlaylists,
+    removePlaylist,
     setFilter,
     setCurrentPlaylistId,
     playlists,

--- a/src/popup/src/modules/Sniffer/SnifferModule.test.tsx
+++ b/src/popup/src/modules/Sniffer/SnifferModule.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { configureStore } from "@reduxjs/toolkit";
+import type { Playlist } from "@hls-downloader/core/lib/entities";
+import { rootReducer } from "@hls-downloader/core/lib/store/root-reducer";
+import { Provider } from "react-redux";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import SnifferModule from "./SnifferModule";
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Array<{ root: Root; container: HTMLDivElement }> = [];
+
+const createPlaylist = (
+  id: string,
+  uri: string,
+  createdAt: number,
+  pageTitle: string
+): Playlist =>
+  ({
+    id,
+    uri,
+    createdAt,
+    pageTitle,
+    initiator: "hls.js",
+  } as Playlist);
+
+afterEach(() => {
+  for (const { root, container } of roots.splice(0)) {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  }
+});
+
+function renderSniffer() {
+  const store = configureStore({
+    reducer: rootReducer,
+    preloadedState: {
+      playlists: {
+        playlists: {
+          first: createPlaylist(
+            "first",
+            "https://example.com/first.m3u8",
+            2,
+            "First Video"
+          ),
+          second: createPlaylist(
+            "second",
+            "https://example.com/second.m3u8",
+            1,
+            "Second Video"
+          ),
+        },
+        playlistsStatus: {
+          first: { status: "ready" },
+          second: { status: "ready" },
+        },
+      },
+    } as any,
+  });
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push({ root, container });
+
+  act(() => {
+    root.render(
+      <Provider store={store}>
+        <SnifferModule />
+      </Provider>
+    );
+  });
+
+  return { container, store };
+}
+
+function click(element: Element) {
+  act(() => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("SnifferModule", () => {
+  it("removes one sniffed playlist without clearing the list", () => {
+    const { container, store } = renderSniffer();
+
+    expect(container.textContent).toContain("First Video");
+    expect(container.textContent).toContain("Second Video");
+
+    const toggles = container.querySelectorAll(
+      'button[aria-label="Toggle playlist details"]'
+    );
+    click(toggles[0]);
+
+    const removeButtons = Array.from(
+      container.querySelectorAll("button")
+    ).filter((button) => button.textContent?.includes("Remove"));
+    click(removeButtons[0]);
+
+    expect(container.textContent).not.toContain("First Video");
+    expect(container.textContent).toContain("Second Video");
+    expect(store.getState().playlists.playlists.first).toBeUndefined();
+    expect(store.getState().playlists.playlists.second?.uri).toBe(
+      "https://example.com/second.m3u8"
+    );
+  });
+});

--- a/src/popup/src/modules/Sniffer/SnifferModule.tsx
+++ b/src/popup/src/modules/Sniffer/SnifferModule.tsx
@@ -11,6 +11,7 @@ const SnifferModule = () => {
     playlists,
     currentPlaylistId,
     copyPlaylistsToClipboard,
+    removePlaylist,
     directURI,
     setDirectURI,
     addDirectPlaylist,
@@ -22,6 +23,7 @@ const SnifferModule = () => {
     <SnifferView
       filter={filter}
       clearPlaylists={clearPlaylists}
+      removePlaylist={removePlaylist}
       copyPlaylistsToClipboard={copyPlaylistsToClipboard}
       setFilter={setFilter}
       setCurrentPlaylistId={setCurrentPlaylistId}

--- a/src/popup/src/modules/Sniffer/SnifferView.stories.tsx
+++ b/src/popup/src/modules/Sniffer/SnifferView.stories.tsx
@@ -52,6 +52,7 @@ export const Empty: Story = {
       currentPlaylistId={undefined}
       filter=""
       clearPlaylists={() => {}}
+      removePlaylist={() => {}}
       setFilter={() => {}}
       setCurrentPlaylistId={() => {}}
       directURI=""
@@ -71,6 +72,7 @@ export const WithItems: Story = {
       currentPlaylistId={undefined}
       filter=""
       clearPlaylists={() => {}}
+      removePlaylist={() => {}}
       setFilter={() => {}}
       setCurrentPlaylistId={() => {}}
       directURI=""
@@ -90,6 +92,7 @@ export const Selected: Story = {
       currentPlaylistId="1"
       filter=""
       clearPlaylists={() => {}}
+      removePlaylist={() => {}}
       setFilter={() => {}}
       setCurrentPlaylistId={() => {}}
       directURI=""
@@ -109,6 +112,7 @@ export const LongTitles: Story = {
       currentPlaylistId={undefined}
       filter=""
       clearPlaylists={() => {}}
+      removePlaylist={() => {}}
       setFilter={() => {}}
       setCurrentPlaylistId={() => {}}
       directURI=""
@@ -128,6 +132,7 @@ export const WithManualInput: Story = {
       currentPlaylistId={undefined}
       filter=""
       clearPlaylists={() => {}}
+      removePlaylist={() => {}}
       setFilter={() => {}}
       setCurrentPlaylistId={() => {}}
       directURI="https://example.com/manual.m3u8"
@@ -163,6 +168,11 @@ export const TransitionDemo: Story = {
         filter={filter}
         clearPlaylists={() => {
           setCurrentPlaylistId(undefined);
+        }}
+        removePlaylist={(playlistId) => {
+          setExpandedPlaylists((prev) =>
+            prev.filter((id) => id !== playlistId)
+          );
         }}
         setFilter={setFilter}
         setCurrentPlaylistId={setCurrentPlaylistId}

--- a/src/popup/src/modules/Sniffer/SnifferView.tsx
+++ b/src/popup/src/modules/Sniffer/SnifferView.tsx
@@ -13,6 +13,7 @@ import {
   Copy,
   Radio,
   ArrowRight,
+  Trash2,
 } from "lucide-react";
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import gsap from "gsap";
@@ -23,6 +24,7 @@ interface Props {
   currentPlaylistId: string | undefined;
   filter: string;
   clearPlaylists: () => void;
+  removePlaylist: (playlistId: string) => void;
   copyPlaylistsToClipboard: () => void;
   setFilter: (filter: string) => void;
   setCurrentPlaylistId: (playlistId?: string) => void;
@@ -35,6 +37,7 @@ interface Props {
 
 const SnifferView = ({
   clearPlaylists,
+  removePlaylist,
   copyPlaylistsToClipboard,
   setFilter,
   filter,
@@ -199,6 +202,7 @@ const SnifferView = ({
                 expanded={expandedPlaylists.includes(item.id)}
                 onToggle={() => toggleExpandedPlaylist(item.id)}
                 onOpen={() => setCurrentPlaylistId(item.id)}
+                onRemove={() => removePlaylist(item.id)}
               />
             ))}
           </ScrollArea>
@@ -215,11 +219,13 @@ const PlaylistRow = ({
   expanded,
   onToggle,
   onOpen,
+  onRemove,
 }: {
   playlist: Playlist;
   expanded: boolean;
   onToggle: () => void;
   onOpen: () => void;
+  onRemove: () => void;
 }) => {
   const detailsRef = useRef<HTMLDivElement | null>(null);
 
@@ -308,6 +314,14 @@ const PlaylistRow = ({
               onClick={() => navigator.clipboard?.writeText(playlist.uri)}
             >
               Copy URL <Copy className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="gap-1"
+              onClick={onRemove}
+            >
+              Remove <Trash2 className="h-3.5 w-3.5" />
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add a per-playlist Remove action in the Sniffer list.
- Wire the action through the sniffer controller to the existing playlist removal flow so related levels, inspections, and preferences are cleaned up by existing epics.
- Add a Redux-backed behavior test that removes one sniffed playlist and verifies the rest of the list remains.

## Why
Issue #241 asks for a way to delete individual sniffed playlists after using or dismissing them. The store already had removal support, but the Sniffer UI did not expose it.

## Validation
- `pnpm --filter ./src/popup run test`
- `pnpm --filter ./src/popup run build`