### PR TITLE
feat: add configurable MKV output

### DIFF
--- a/src/background/src/offscreen.ts
+++ b/src/background/src/offscreen.ts
@@ -1,4 +1,5 @@
 import { IndexedDBFS } from "./services/indexedb-fs";
+import type { OutputContainer } from "@hls-downloader/core/lib/entities";
 
 type OffscreenRequest = {
   target?: string;
@@ -7,6 +8,7 @@ type OffscreenRequest = {
   requestId?: string;
   videoLength?: number;
   audioLength?: number;
+  container?: OutputContainer;
 };
 
 type OffscreenResponse =
@@ -59,19 +61,22 @@ async function handleCreateObjectUrl(
     return { ok: false, message: `Bucket ${message.bucketId} not found` };
   }
 
-  const url = await bucket.getLink((progress, status) => {
-    if (!message.requestId) {
-      return;
-    }
+  const url = await bucket.getLink(
+    (progress, status) => {
+      if (!message.requestId) {
+        return;
+      }
 
-    void chrome.runtime.sendMessage({
-      target: "background",
-      type: "offscreen-progress",
-      requestId: message.requestId,
-      progress,
-      message: status,
-    });
-  });
+      void chrome.runtime.sendMessage({
+        target: "background",
+        type: "offscreen-progress",
+        requestId: message.requestId,
+        progress,
+        message: status,
+      });
+    },
+    { container: message.container ?? "mp4" }
+  );
 
   return { ok: true, url };
 }

--- a/src/background/src/services/ffmpeg-muxer.ts
+++ b/src/background/src/services/ffmpeg-muxer.ts
@@ -32,6 +32,10 @@ function isMp4ContainerFile(fileName: string): boolean {
   return /\.(m4a|m4v|mp4)$/i.test(fileName);
 }
 
+function getMimeForOutputFile(fileName: string): string {
+  return /\.mkv$/i.test(fileName) ? "video/x-matroska" : "video/mp4";
+}
+
 export async function writeMediaToFFmpegFS(
   ffmpeg: FFmpeg,
   filename: string,
@@ -132,7 +136,7 @@ export async function muxExec({
       throw new Error(`FFmpeg exited with code ${exitCode}`);
     }
     const data = await ffmpeg.readFile(outputFileName);
-    const mime = includeSubtitles ? "video/x-matroska" : "video/mp4";
+    const mime = getMimeForOutputFile(outputFileName);
     return { blob: new Blob([data], { type: mime }), mime };
   } finally {
     const cleanupFiles = [

--- a/src/background/src/services/indexedb-fs.ts
+++ b/src/background/src/services/indexedb-fs.ts
@@ -6,10 +6,11 @@ import {
   IDBPCursorWithValue,
 } from "idb";
 
-import {
+import type {
   Bucket,
   IFS,
   StorageSnapshot,
+  GetLinkOptions,
 } from "@hls-downloader/core/lib/services";
 import browser from "webextension-polyfill";
 import filenamify from "filenamify";
@@ -31,6 +32,8 @@ type BucketMeta = {
   storedChunks?: number;
   updatedAt?: number;
 };
+
+type OutputContainer = NonNullable<GetLinkOptions["container"]>;
 
 let bucketMetaCache: Record<string, BucketMeta> | null = null;
 
@@ -377,9 +380,11 @@ export class IndexedDBBucket implements Bucket {
   }
 
   async getLink(
-    onProgress?: (progress: number, message: string) => void
+    onProgress?: (progress: number, message: string) => void,
+    options: GetLinkOptions = {}
   ): Promise<string> {
     await this.ensureDb();
+    const container = options.container ?? "mp4";
 
     if (shouldUseOffscreen()) {
       return await requestObjectUrlOffscreen(
@@ -387,14 +392,15 @@ export class IndexedDBBucket implements Bucket {
           bucketId: this.id,
           videoLength: this.videoLength,
           audioLength: this.audioLength,
+          container,
         },
         onProgress
       );
     }
 
     try {
-      const mp4Blob = await this.streamToMp4Blob(onProgress);
-      const url = URL.createObjectURL(mp4Blob);
+      const mediaBlob = await this.streamToMediaBlob(container, onProgress);
+      const url = URL.createObjectURL(mediaBlob);
       return url;
     } catch (error) {
       console.error("getLink failed:", error);
@@ -403,7 +409,8 @@ export class IndexedDBBucket implements Bucket {
     }
   }
 
-  private async streamToMp4Blob(
+  private async streamToMediaBlob(
+    container: OutputContainer,
     onProgress?: (progress: number, message: string) => void
   ) {
     await this.ensureDb();
@@ -412,8 +419,9 @@ export class IndexedDBBucket implements Bucket {
 
     const subtitle = await getSubtitleText(this.id);
     const includeSubtitles = subtitle !== undefined;
+    const outputContainer = includeSubtitles ? "mkv" : container;
     // write somewhere predictable (avoid path/punctuation issues)
-    const outputFileName = includeSubtitles ? "output.mkv" : "output.mp4";
+    const outputFileName = `output.${outputContainer}`;
 
     const hasVideo = this.videoLength > 0;
     const hasAudio = this.audioLength > 0;
@@ -745,6 +753,7 @@ async function requestObjectUrlOffscreen(
     bucketId: string;
     videoLength: number;
     audioLength: number;
+    container: OutputContainer;
   },
   onProgress?: (progress: number, message: string) => void
 ) {
@@ -774,6 +783,7 @@ async function requestObjectUrlOffscreen(
         bucketId: payload.bucketId,
         videoLength: payload.videoLength,
         audioLength: payload.audioLength,
+        container: payload.container,
         requestId,
       },
       (response: { ok: boolean; url?: string; message?: string }) => {

--- a/src/background/test/ffmpeg-muxer.test.ts
+++ b/src/background/test/ffmpeg-muxer.test.ts
@@ -195,6 +195,17 @@ describe("muxExec", () => {
     expect(result.mime).toBe("video/x-matroska");
   });
 
+  it("returns video/x-matroska MIME for mkv output without subtitles", async () => {
+    const result = await muxExec({
+      ffmpeg,
+      outputFileName: "output.mkv",
+      hasVideo: true,
+      hasAudio: false,
+    });
+
+    expect(result.mime).toBe("video/x-matroska");
+  });
+
   it("cleanup: deleteFile called for all written files", async () => {
     await muxExec({
       ffmpeg,

--- a/src/background/test/mux-pipeline.integration.test.ts
+++ b/src/background/test/mux-pipeline.integration.test.ts
@@ -184,6 +184,22 @@ describe("Mux Pipeline Integration", () => {
     await IndexedDBFS.deleteBucket(id);
   });
 
+  it("uses requested mkv output without subtitles", async () => {
+    const id = "mkv-output-test";
+    await IndexedDBFS.createBucket(id, 1, 1);
+    const bucket = (await IndexedDBFS.getBucket(id)) as IndexedDBBucket;
+
+    await bucket.write(0, videoOnly.buffer);
+    await bucket.write(1, audioOnly.buffer);
+
+    await bucket.getLink(undefined, { container: "mkv" });
+
+    const args = mock.getExecArgs()[0];
+    expect(args).toContain("output.mkv");
+
+    await IndexedDBFS.deleteBucket(id);
+  });
+
   it("muxed with extra stream: maps 0:v and 0:a?, not bare 0", async () => {
     const id = "data-stream-test";
     await IndexedDBFS.createBucket(id, 1, 0);

--- a/src/background/test/persistState.test.ts
+++ b/src/background/test/persistState.test.ts
@@ -100,5 +100,23 @@ describe("persistState", () => {
       expect(result).not.toHaveProperty("downloads");
       expect(result).not.toHaveProperty("ui");
     });
+
+    it("defaults output container to mp4 for older persisted config", async () => {
+      mockGet.mockResolvedValue({ state: { config: {} } });
+
+      const result = await getState();
+
+      expect(result?.config?.outputContainer).toBe("mp4");
+    });
+
+    it("preserves persisted mkv output container", async () => {
+      mockGet.mockResolvedValue({
+        state: { config: { outputContainer: "mkv" } },
+      });
+
+      const result = await getState();
+
+      expect(result?.config?.outputContainer).toBe("mkv");
+    });
   });
 });

--- a/src/core/src/controllers/add-download-job-epic.ts
+++ b/src/core/src/controllers/add-download-job-epic.ts
@@ -11,6 +11,7 @@ import {
   storeSubtitleTextFactory,
 } from "../use-cases";
 import { jobsSlice } from "../store/slices/jobs-slice";
+import type { OutputContainer } from "../entities";
 
 export const addDownloadJobEpic: Epic<
   RootAction,
@@ -79,7 +80,11 @@ export const addDownloadJobEpic: Epic<
                 : Promise.resolve(null),
             ]);
 
-          const container = subtitleLevel ? "mkv" : "mp4";
+          const configuredContainer =
+            store$.value.config.outputContainer ?? "mp4";
+          const container: OutputContainer = subtitleLevel
+            ? "mkv"
+            : configuredContainer;
           const actions: RootAction[] = [
             jobsSlice.actions.add({
               job: {
@@ -90,6 +95,7 @@ export const addDownloadJobEpic: Epic<
                 filename: generateFileName()(playlist, videoLevel, {
                   container,
                 }),
+                outputContainer: container,
                 createdAt: Date.now(),
                 bitrate: videoLevel.bitrate,
                 width: videoLevel.width,

--- a/src/core/src/controllers/save-as-job-epic.ts
+++ b/src/core/src/controllers/save-as-job-epic.ts
@@ -18,6 +18,9 @@ export const saveAsJobEpic: Epic<
     mergeMap((jobId) => {
       const job = store$.value.jobs.jobs[jobId]!;
       const dialog = store$.value.config.saveDialog;
+      const container =
+        job.outputContainer ??
+        (job.filename.toLowerCase().endsWith(".mkv") ? "mkv" : "mp4");
 
       const ensureSubtitle$ =
         job?.subtitleText !== undefined && job.subtitleText !== null
@@ -42,12 +45,15 @@ export const saveAsJobEpic: Epic<
       return ensureSubtitle$.pipe(
         mergeMap(() =>
           from(
-            getLinkBucketFactory(fs)(jobId, (progress, message) =>
-              jobsSlice.actions.setSaveProgress({
-                jobId,
-                progress,
-                message,
-              })
+            getLinkBucketFactory(fs)(
+              jobId,
+              (progress, message) =>
+                jobsSlice.actions.setSaveProgress({
+                  jobId,
+                  progress,
+                  message,
+                }),
+              { container }
             )
           )
         ),

--- a/src/core/src/entities/index.ts
+++ b/src/core/src/entities/index.ts
@@ -7,3 +7,4 @@ export * from "./playlist-status";
 export * from "./job";
 export * from "./job-status";
 export * from "./inspection";
+export * from "./output-container";

--- a/src/core/src/entities/job.ts
+++ b/src/core/src/entities/job.ts
@@ -1,4 +1,5 @@
 import { Fragment } from "./fragment";
+import type { OutputContainer } from "./output-container";
 
 export class Job {
   constructor(
@@ -14,6 +15,7 @@ export class Job {
     readonly link?: string,
     readonly subtitleText?: string,
     readonly subtitleLanguage?: string,
-    readonly subtitleName?: string
+    readonly subtitleName?: string,
+    readonly outputContainer?: OutputContainer
   ) {}
 }

--- a/src/core/src/entities/output-container.ts
+++ b/src/core/src/entities/output-container.ts
@@ -1,0 +1,1 @@
+export type OutputContainer = "mp4" | "mkv";

--- a/src/core/src/services/fs.ts
+++ b/src/core/src/services/fs.ts
@@ -1,3 +1,9 @@
+import type { OutputContainer } from "../entities";
+
+export type GetLinkOptions = {
+  container?: OutputContainer;
+};
+
 export interface IFS {
   cleanup(): Promise<void>;
   getBucket(id: string): Promise<Bucket>;
@@ -27,7 +33,8 @@ export interface IFS {
 export interface Bucket {
   write(index: number, data: ArrayBuffer): Promise<void>;
   getLink(
-    onProgress?: (progress: number, message: string) => void
+    onProgress?: (progress: number, message: string) => void,
+    options?: GetLinkOptions
   ): Promise<string>;
 }
 

--- a/src/core/src/store/slices/config-slice.ts
+++ b/src/core/src/store/slices/config-slice.ts
@@ -4,6 +4,7 @@ import {
   Slice,
   CaseReducer,
 } from "@reduxjs/toolkit";
+import type { OutputContainer } from "../../entities";
 
 export interface ISetConcurrencyPayload {
   concurrency: number;
@@ -28,6 +29,10 @@ export interface ISetAutoDeleteAfterSavePayload {
   autoDeleteAfterSave: boolean;
 }
 
+export interface ISetOutputContainerPayload {
+  outputContainer: OutputContainer;
+}
+
 export interface IConfigState {
   concurrency: number;
   saveDialog: boolean;
@@ -35,6 +40,7 @@ export interface IConfigState {
   preferredAudioLanguage: string | null;
   maxActiveDownloads: number;
   autoDeleteAfterSave: boolean;
+  outputContainer: OutputContainer;
 }
 
 interface IConfigReducers {
@@ -62,6 +68,10 @@ interface IConfigReducers {
     IConfigState,
     PayloadAction<ISetAutoDeleteAfterSavePayload>
   >;
+  setOutputContainer: CaseReducer<
+    IConfigState,
+    PayloadAction<ISetOutputContainerPayload>
+  >;
   [key: string]: CaseReducer<IConfigState, PayloadAction<any>>;
 }
 
@@ -72,6 +82,7 @@ export const initialConfigState: IConfigState = {
   preferredAudioLanguage: null,
   maxActiveDownloads: 0,
   autoDeleteAfterSave: false,
+  outputContainer: "mp4",
 };
 
 export const configSlice: Slice<IConfigState, IConfigReducers, "config"> =
@@ -105,6 +116,12 @@ export const configSlice: Slice<IConfigState, IConfigReducers, "config"> =
         action: PayloadAction<ISetAutoDeleteAfterSavePayload>
       ) {
         state.autoDeleteAfterSave = action.payload.autoDeleteAfterSave;
+      },
+      setOutputContainer(
+        state,
+        action: PayloadAction<ISetOutputContainerPayload>
+      ) {
+        state.outputContainer = action.payload.outputContainer;
       },
     },
   });

--- a/src/core/src/use-cases/generate-file-name.ts
+++ b/src/core/src/use-cases/generate-file-name.ts
@@ -1,8 +1,9 @@
 import { Playlist, Level } from "../entities";
+import type { OutputContainer } from "../entities/output-container";
 import { sanitizeFilename } from "./sanitize-filename";
 
 type GenerateFileNameOptions = {
-  container?: "mp4" | "mkv";
+  container?: OutputContainer;
 };
 
 export const generateFileName = () => {

--- a/src/core/src/use-cases/get-link-bucket.ts
+++ b/src/core/src/use-cases/get-link-bucket.ts
@@ -1,12 +1,13 @@
-import { IFS } from "../services";
+import type { GetLinkOptions, IFS } from "../services";
 
 export const getLinkBucketFactory = (fs: IFS) => {
   const run = async (
     bucketID: string,
-    onProgress?: (progress: number, message: string) => void
+    onProgress?: (progress: number, message: string) => void,
+    options?: GetLinkOptions
   ): Promise<string> => {
     const bucket = await fs.getBucket(bucketID);
-    return await bucket.getLink(onProgress);
+    return await bucket.getLink(onProgress, options);
   };
   return run;
 };

--- a/src/core/test/add-download-job-epic.test.ts
+++ b/src/core/test/add-download-job-epic.test.ts
@@ -10,6 +10,7 @@ import {
   createMockState,
   createMockLoader,
   createMockParser,
+  createMockFS,
   toObservable,
 } from "./test-utils";
 
@@ -17,11 +18,13 @@ describe("addDownloadJobEpic", () => {
   // Setup test fixtures
   let videoLevel;
   let audioLevel;
+  let subtitleLevel;
   let playlist;
   let videoFragment;
   let audioFragment;
   let mockLoader;
   let mockParser;
+  let mockFS;
   let mockState;
 
   beforeEach(() => {
@@ -42,6 +45,13 @@ describe("addDownloadJobEpic", () => {
       type: "audio",
     });
 
+    subtitleLevel = createTestLevel({
+      id: "s",
+      playlistID: "p",
+      uri: "subtitle",
+      type: "subtitle",
+    });
+
     playlist = createTestPlaylist({
       id: "p",
       uri: "http://example.com/master.m3u8",
@@ -54,6 +64,7 @@ describe("addDownloadJobEpic", () => {
     // Create mock services
     mockLoader = createMockLoader();
     mockParser = createMockParser();
+    mockFS = createMockFS();
 
     // Configure mock parser to return different fragments based on URI
     mockParser.parseLevelPlaylist = vi
@@ -64,7 +75,7 @@ describe("addDownloadJobEpic", () => {
 
     // Create mock state
     mockState = createMockState({
-      levels: { v: videoLevel, a: audioLevel },
+      levels: { v: videoLevel, a: audioLevel, s: subtitleLevel },
       playlists: { p: playlist },
       fetchAttempts: 1,
     });
@@ -90,6 +101,7 @@ describe("addDownloadJobEpic", () => {
     const { job } = (result as any).payload;
     expect(job).toMatchObject({
       filename: "page-master.mp4",
+      outputContainer: "mp4",
       videoFragments: [videoFragment],
       audioFragments: [audioFragment],
       bitrate: 1000,
@@ -166,6 +178,42 @@ describe("addDownloadJobEpic", () => {
     expect((result as any).payload.job.filename).toBe(
       "My Custom Title-master.mp4"
     );
+  });
+
+  it("uses configured mkv output for new download jobs", async () => {
+    mockState.config.outputContainer = "mkv";
+    const action$ = toObservable(
+      levelsSlice.actions.download({ levelID: "v", audioLevelID: "a" })
+    );
+    const deps = { loader: mockLoader, parser: mockParser };
+
+    const result = await firstValueFrom(
+      addDownloadJobEpic(action$, { value: mockState } as any, deps as any)
+    );
+
+    expect(result.type).toBe(jobsSlice.actions.add.type);
+    expect((result as any).payload.job).toMatchObject({
+      filename: "page-master.mkv",
+      outputContainer: "mkv",
+    });
+  });
+
+  it("forces mkv output when subtitles are selected", async () => {
+    mockState.config.outputContainer = "mp4";
+    const action$ = toObservable(
+      levelsSlice.actions.download({ levelID: "v", subtitleLevelID: "s" })
+    );
+    const deps = { loader: mockLoader, parser: mockParser, fs: mockFS };
+
+    const result = await firstValueFrom(
+      addDownloadJobEpic(action$, { value: mockState } as any, deps as any)
+    );
+
+    expect(result.type).toBe(jobsSlice.actions.add.type);
+    expect((result as any).payload.job).toMatchObject({
+      filename: "page-master.mkv",
+      outputContainer: "mkv",
+    });
   });
 
   it("handles errors when fetching fragments", async () => {

--- a/src/core/test/fs-cleanup-epic.test.ts
+++ b/src/core/test/fs-cleanup-epic.test.ts
@@ -10,6 +10,8 @@ describe("fsCleanupOnInitEpic", () => {
       getBucket: vi.fn(),
       createBucket: vi.fn(),
       deleteBucket: vi.fn(),
+      setSubtitleText: vi.fn(),
+      getSubtitleText: vi.fn(),
       saveAs: vi.fn(),
       getStorageStats: vi.fn(),
     };

--- a/src/core/test/save-as-job-epic.test.ts
+++ b/src/core/test/save-as-job-epic.test.ts
@@ -7,9 +7,10 @@ import { Job } from "../src/entities/index.ts";
 describe("saveAsJobEpic", () => {
   it("saves job to file and emits success", async () => {
     const job = new Job("1", "p1", [], [], "file.mp4", Date.now());
+    const getLink = vi.fn().mockResolvedValue("link");
     const fs = {
       getBucket: vi.fn().mockResolvedValue({
-        getLink: vi.fn().mockResolvedValue("link"),
+        getLink,
       }),
       saveAs: vi.fn().mockResolvedValue(undefined),
     };
@@ -24,8 +25,43 @@ describe("saveAsJobEpic", () => {
     expect(fs.saveAs).toHaveBeenCalledWith("file.mp4", "link", {
       dialog: true,
     });
+    expect(getLink).toHaveBeenCalledWith(expect.any(Function), {
+      container: "mp4",
+    });
     expect(result).toEqual(
       jobsSlice.actions.saveAsSuccess({ jobId: "1", link: "link" })
     );
+  });
+
+  it("passes stored mkv output container when creating the save link", async () => {
+    const job = {
+      id: "1",
+      playlistId: "p1",
+      videoFragments: [],
+      audioFragments: [],
+      filename: "file.mkv",
+      createdAt: Date.now(),
+      outputContainer: "mkv" as const,
+    };
+    const getLink = vi.fn().mockResolvedValue("link");
+    const fs = {
+      getBucket: vi.fn().mockResolvedValue({
+        getLink,
+      }),
+      saveAs: vi.fn().mockResolvedValue(undefined),
+    };
+    const action$ = of(jobsSlice.actions.saveAs({ jobId: "1" }));
+    const state = {
+      jobs: { jobs: { "1": job } },
+      config: { saveDialog: false },
+    };
+
+    await firstValueFrom(
+      saveAsJobEpic(action$, { value: state } as any, { fs } as any)
+    );
+
+    expect(getLink).toHaveBeenCalledWith(expect.any(Function), {
+      container: "mkv",
+    });
   });
 });

--- a/src/core/test/slices.test.ts
+++ b/src/core/test/slices.test.ts
@@ -32,6 +32,11 @@ describe("store slices", () => {
       configSlice.actions.setMaxActiveDownloads({ maxActiveDownloads: 3 })
     );
     expect(state.maxActiveDownloads).toBe(3);
+    state = configSlice.reducer(
+      state,
+      configSlice.actions.setOutputContainer({ outputContainer: "mkv" })
+    );
+    expect(state.outputContainer).toBe("mkv");
   });
 
   it("jobs slice reducers", () => {

--- a/src/core/test/test-utils.ts
+++ b/src/core/test/test-utils.ts
@@ -19,6 +19,7 @@ import {
   Job,
   JobStatus,
 } from "../src/entities";
+import type { LevelType, OutputContainer } from "../src/entities";
 
 /**
  * Create mock loader with configurable responses
@@ -106,7 +107,10 @@ export function createMockBucket(
     getLink: vi
       .fn()
       .mockImplementation(
-        (onProgress?: (progress: number, message: string) => void) => {
+        (
+          onProgress?: (progress: number, message: string) => void,
+          _options?: { container?: OutputContainer }
+        ) => {
           if (onProgress) {
             onProgress(0, "Starting");
             onProgress(50, "Halfway");
@@ -141,6 +145,8 @@ export function createMockFS(
     getBucket: vi.fn().mockResolvedValue(bucket),
     createBucket: vi.fn().mockResolvedValue(undefined),
     deleteBucket: vi.fn().mockResolvedValue(undefined),
+    setSubtitleText: vi.fn().mockResolvedValue(undefined),
+    getSubtitleText: vi.fn().mockResolvedValue(undefined),
     saveAs: vi.fn().mockResolvedValue(undefined),
     getStorageStats: vi.fn().mockResolvedValue(storageSnapshot),
   };
@@ -206,7 +212,7 @@ export function createTestLevel(
     id?: string;
     playlistID?: string;
     uri?: string;
-    type?: "stream" | "audio";
+    type?: LevelType;
     width?: number;
     height?: number;
     bitrate?: number;
@@ -341,6 +347,7 @@ export function createMockState(
     tabId?: number;
     maxActiveDownloads?: number;
     preferredAudioLanguage?: string | null;
+    outputContainer?: OutputContainer;
   } = {}
 ): any {
   const {
@@ -356,6 +363,7 @@ export function createMockState(
     tabId = 1,
     maxActiveDownloads = 0,
     preferredAudioLanguage = null,
+    outputContainer = "mp4",
   } = options;
 
   return {
@@ -377,6 +385,7 @@ export function createMockState(
       saveDialog,
       maxActiveDownloads,
       preferredAudioLanguage,
+      outputContainer,
     },
     tabs: {
       current: {

--- a/src/core/test/use-cases.test.ts
+++ b/src/core/test/use-cases.test.ts
@@ -35,6 +35,8 @@ const createFsMock = () => {
     createBucket: vi.fn().mockResolvedValue(undefined),
     deleteBucket: vi.fn().mockResolvedValue(undefined),
     getBucket: vi.fn().mockResolvedValue(bucket),
+    setSubtitleText: vi.fn().mockResolvedValue(undefined),
+    getSubtitleText: vi.fn().mockResolvedValue(undefined),
     saveAs: vi.fn().mockResolvedValue(undefined),
     getStorageStats: vi.fn().mockResolvedValue({
       buckets: [],
@@ -84,6 +86,19 @@ describe("use-cases", () => {
     expect(link).toBe("link");
   });
 
+  it("passes output options when getting a link from bucket", async () => {
+    const { fs, bucket } = createFsMock();
+    const onProgress = vi.fn();
+    const link = await getLinkBucketFactory(fs)("id", onProgress, {
+      container: "mkv",
+    });
+
+    expect(bucket.getLink).toHaveBeenCalledWith(onProgress, {
+      container: "mkv",
+    });
+    expect(link).toBe("link");
+  });
+
   it("generates file name with page title", () => {
     const playlist = new Playlist(
       "1",
@@ -94,6 +109,18 @@ describe("use-cases", () => {
     const level = new Level("stream", "l", "1", "uri");
     const run = generateFileName();
     expect(run(playlist, level)).toBe("page-c.mp4");
+  });
+
+  it("generates mkv file name when requested", () => {
+    const playlist = new Playlist(
+      "1",
+      "https://a/b/c.m3u8",
+      Date.now(),
+      "page"
+    );
+    const level = new Level("stream", "l", "1", "uri");
+    const run = generateFileName();
+    expect(run(playlist, level, { container: "mkv" })).toBe("page-c.mkv");
   });
 
   it("sanitizes illegal characters in page title", () => {

--- a/src/popup/src/modules/Settings/SettingsController.ts
+++ b/src/popup/src/modules/Settings/SettingsController.ts
@@ -1,5 +1,6 @@
-import { RootState } from "@hls-downloader/core/lib/store/root-reducer";
+import type { RootState } from "@hls-downloader/core/lib/store/root-reducer";
 import { configSlice } from "@hls-downloader/core/lib/store/slices";
+import type { OutputContainer } from "@hls-downloader/core/lib/entities";
 import { useDispatch, useSelector } from "react-redux";
 
 interface ReturnType {
@@ -8,6 +9,7 @@ interface ReturnType {
   fetchAttempts: number;
   saveDialog: boolean;
   autoDeleteAfterSave: boolean;
+  outputContainer: OutputContainer;
   onFetchAttemptsIncrease: () => void;
   onFetchAttemptsDecrease: () => void;
   onSaveDialogToggle: () => void;
@@ -19,6 +21,7 @@ interface ReturnType {
   onActiveDownloadsUnlimited: () => void;
   preferredAudioLanguage: string | null;
   onSetPreferredAudioLanguage: (lang: string | null) => void;
+  onSetOutputContainer: (outputContainer: OutputContainer) => void;
   activeDownloadsUnlimited: boolean;
 }
 
@@ -41,6 +44,9 @@ const useSettingsController = (): ReturnType => {
   );
   const autoDeleteAfterSave = useSelector<RootState, boolean>(
     (state) => state.config.autoDeleteAfterSave
+  );
+  const outputContainer = useSelector<RootState, OutputContainer>(
+    (state) => state.config.outputContainer ?? "mp4"
   );
   const activeDownloadsUnlimited = maxActiveDownloads === 0;
 
@@ -117,6 +123,13 @@ const useSettingsController = (): ReturnType => {
       })
     );
   }
+  function onSetOutputContainer(outputContainer: OutputContainer) {
+    dispatch(
+      configSlice.actions.setOutputContainer({
+        outputContainer,
+      })
+    );
+  }
   return {
     concurrency,
     maxActiveDownloads,
@@ -129,12 +142,14 @@ const useSettingsController = (): ReturnType => {
     fetchAttempts,
     saveDialog,
     autoDeleteAfterSave,
+    outputContainer,
     onFetchAttemptsIncrease,
     onFetchAttemptsDecrease,
     onSaveDialogToggle,
     onAutoDeleteAfterSaveToggle,
     preferredAudioLanguage,
     onSetPreferredAudioLanguage,
+    onSetOutputContainer,
   };
 };
 

--- a/src/popup/src/modules/Settings/SettingsModule.tsx
+++ b/src/popup/src/modules/Settings/SettingsModule.tsx
@@ -15,8 +15,10 @@ const SettingsModule = () => {
     saveDialog,
     autoDeleteAfterSave,
     concurrency,
+    outputContainer,
     preferredAudioLanguage,
     onSetPreferredAudioLanguage,
+    onSetOutputContainer,
     maxActiveDownloads,
     activeDownloadsUnlimited,
     onActiveDownloadsDecrease,
@@ -37,6 +39,8 @@ const SettingsModule = () => {
       onConcurrencyDecrease={onConcurrencyDecrease}
       onConcurrencyIncrease={onConcurrencyIncrease}
       concurrency={concurrency}
+      outputContainer={outputContainer}
+      onSetOutputContainer={onSetOutputContainer}
       preferredAudioLanguage={preferredAudioLanguage}
       onSetPreferredAudioLanguage={onSetPreferredAudioLanguage}
       maxActiveDownloads={maxActiveDownloads}

--- a/src/popup/src/modules/Settings/SettingsView.stories.tsx
+++ b/src/popup/src/modules/Settings/SettingsView.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import SettingsView from "./SettingsView";
+import type { StorageState } from "@hls-downloader/core/lib/store/slices/storage-slice";
 
 const meta: Meta<typeof SettingsView> = {
   title: "popup/views/SettingsView",
@@ -8,6 +9,15 @@ const meta: Meta<typeof SettingsView> = {
 
 export default meta;
 type Story = StoryObj<typeof SettingsView>;
+
+const storage: StorageState = {
+  loading: false,
+  buckets: {},
+  totalUsedBytes: 0,
+  estimateSource: "unknown",
+  nearQuota: false,
+  cleanupStatus: "idle",
+};
 
 export const Default: Story = {
   render: () => (
@@ -18,6 +28,7 @@ export const Default: Story = {
       fetchAttempts={5}
       saveDialog={true}
       autoDeleteAfterSave={false}
+      outputContainer="mp4"
       onConcurrencyIncrease={() => {}}
       onConcurrencyDecrease={() => {}}
       onActiveDownloadsIncrease={() => {}}
@@ -27,8 +38,12 @@ export const Default: Story = {
       onFetchAttemptsDecrease={() => {}}
       onSaveDialogToggle={() => {}}
       onAutoDeleteAfterSaveToggle={() => {}}
+      onSetOutputContainer={() => {}}
       preferredAudioLanguage={"eng"}
       onSetPreferredAudioLanguage={() => {}}
+      storage={storage}
+      onCleanupStorage={() => {}}
+      onRefreshStorage={() => {}}
     />
   ),
 };
@@ -42,6 +57,7 @@ export const Minimal: Story = {
       fetchAttempts={1}
       saveDialog={false}
       autoDeleteAfterSave={true}
+      outputContainer="mkv"
       onConcurrencyIncrease={() => {}}
       onConcurrencyDecrease={() => {}}
       onActiveDownloadsIncrease={() => {}}
@@ -51,8 +67,12 @@ export const Minimal: Story = {
       onFetchAttemptsDecrease={() => {}}
       onSaveDialogToggle={() => {}}
       onAutoDeleteAfterSaveToggle={() => {}}
+      onSetOutputContainer={() => {}}
       preferredAudioLanguage={null}
       onSetPreferredAudioLanguage={() => {}}
+      storage={storage}
+      onCleanupStorage={() => {}}
+      onRefreshStorage={() => {}}
     />
   ),
 };

--- a/src/popup/src/modules/Settings/SettingsView.tsx
+++ b/src/popup/src/modules/Settings/SettingsView.tsx
@@ -1,7 +1,8 @@
-import { Button, Switch, Input, Card } from "@hls-downloader/design-system";
+import { Button, Switch, Card } from "@hls-downloader/design-system";
 import React from "react";
 import StorageSummary from "../Storage/StorageSummary";
-import { StorageState } from "@hls-downloader/core/lib/store/slices/storage-slice";
+import type { StorageState } from "@hls-downloader/core/lib/store/slices/storage-slice";
+import type { OutputContainer } from "@hls-downloader/core/lib/entities";
 
 interface Props {
   concurrency: number;
@@ -10,6 +11,7 @@ interface Props {
   fetchAttempts: number;
   saveDialog: boolean;
   autoDeleteAfterSave: boolean;
+  outputContainer: OutputContainer;
   onFetchAttemptsIncrease: () => void;
   onFetchAttemptsDecrease: () => void;
   onSaveDialogToggle: () => void;
@@ -19,6 +21,7 @@ interface Props {
   onActiveDownloadsIncrease: () => void;
   onActiveDownloadsDecrease: () => void;
   onActiveDownloadsUnlimited: () => void;
+  onSetOutputContainer: (outputContainer: OutputContainer) => void;
   preferredAudioLanguage?: string | null;
   onSetPreferredAudioLanguage: (lang: string | null) => void;
   storage: StorageState;
@@ -58,11 +61,17 @@ const LANG_OPTIONS = [
   { code: "ukr", label: "Ukrainian" },
 ];
 
+const OUTPUT_CONTAINER_OPTIONS: { value: OutputContainer; label: string }[] = [
+  { value: "mp4", label: "MP4" },
+  { value: "mkv", label: "MKV" },
+];
+
 const SettingsView = ({
   concurrency,
   fetchAttempts,
   saveDialog,
   autoDeleteAfterSave,
+  outputContainer,
   onConcurrencyIncrease,
   onConcurrencyDecrease,
   onActiveDownloadsIncrease,
@@ -74,6 +83,7 @@ const SettingsView = ({
   onFetchAttemptsDecrease,
   onSaveDialogToggle,
   onAutoDeleteAfterSaveToggle,
+  onSetOutputContainer,
   preferredAudioLanguage = "",
   onSetPreferredAudioLanguage,
   storage,
@@ -141,6 +151,30 @@ const SettingsView = ({
             >
               +
             </Button>
+          </div>
+        </Card>
+
+        <Card className="gap-3">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium">Output format</p>
+            <p className="text-[11px] text-muted-foreground">
+              Used for new downloads without subtitles
+            </p>
+          </div>
+          <div className="flex-1 min-w-[240px] border rounded-md">
+            <select
+              className="w-full p-2 text-sm bg-background text-foreground border-r-8 border-r-transparent"
+              value={outputContainer}
+              onChange={(e) =>
+                onSetOutputContainer(e.target.value as OutputContainer)
+              }
+            >
+              {OUTPUT_CONTAINER_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
           </div>
         </Card>
 


### PR DESCRIPTION
## Summary
- Add a Settings-page output format selector for MP4 or MKV, defaulting to MP4.
- Store the resolved output container on each job and pass it through the save/mux pipeline.
- Use Matroska MIME/output naming for MKV downloads while preserving forced MKV for subtitle downloads.

## Tests
- pnpm --filter ./src/core run test
- pnpm --filter ./src/core run build
- pnpm --filter ./src/background run test
- pnpm --filter ./src/design-system run build && pnpm --filter ./src/background run build && pnpm --filter ./src/popup run build
- pnpm test

Closes #538