### PR TITLE
chore(release): prepare v5.5.0

### DIFF
--- a/AMO_SOURCE_REVIEW.md
+++ b/AMO_SOURCE_REVIEW.md
@@ -6,7 +6,7 @@ source archive.
 ## Environment
 
 - Ubuntu 24.04 LTS ARM64
-- Node.js 22.11.0
+- Node.js 22.12.0 or newer
 - npm 10.9.0
 - `zip` command available on `PATH`
 
@@ -14,7 +14,7 @@ source archive.
 
 ```bash
 corepack enable
-corepack prepare pnpm@10.11.0 --activate
+corepack prepare pnpm@10.34.4 --activate
 pnpm install --frozen-lockfile
 pnpm run build:mv2
 ```
@@ -34,7 +34,7 @@ uses that directory as its source package.
 - `dist/extension-mv2-firefox.xpi`
 
 `browser_specific_settings.gecko.id` and
-`browser_specific_settings.gecko.strict_min_version: "115.0"` and
+`browser_specific_settings.gecko.strict_min_version: "128.0"` and
 `data_collection_permissions.required: ["none"]` are committed in
 `src/assets/manifest.json`; no post-build manifest edits are required.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,43 @@
 
 ## Unreleased
 
+## 5.5.0
+
+### Features
+
+- Added an output-format setting for MP4 or MKV; downloads containing subtitles continue to use MKV automatically.
+- Refreshed the popup with more consistent navigation, cards, controls, status presentation, storage information, and responsive scrolling.
+
 ### Fixes
 
-- Replaced media-sized IndexedDB/JavaScript mux buffers for new jobs with an OPFS-backed fragment and export pipeline on Firefox MV2 and Chromium MV3.
-- Added a dedicated FFmpeg worker with WORKERFS inputs and a seekable OPFS output device, producing normal seekable MP4 or MKV files without fragmented-MP4 fallback.
-- Kept pre-existing IndexedDB jobs on an explicit legacy finalization path with actionable re-download errors instead of silently migrating them.
-- Kept download artifacts alive until the browser reports completion or interruption, including duplicate saves and MV3 service-worker wake-ups.
+- Moved new downloads to a disk-backed processing pipeline on Firefox MV2 and Chromium MV3, preventing memory consumption from growing with the complete media size.
+- Added dedicated disk-backed muxing that produces normal seekable MP4 and MKV files.
+- Kept generated artifacts available until the browser confirms completion or interruption, including duplicate saves and MV3 service-worker restarts.
 - Added disk-space preflight checks, safe overwrite accounting, serialized muxing, coalesced repeated finalization, cancellation, and partial-output cleanup.
-- Declared Firefox 115 and Chromium 109 as the minimum supported versions.
-- Request persistent browser storage before creating new disk-backed downloads, increasing the available Firefox storage allowance and protecting temporary media from eviction.
-- Treat storage estimates as informational when the extension has unlimited storage permission, preventing Chromium's conservative 2 GiB report from blocking large-file finalization or triggering false low-space warnings.
-- Reword the storage UI around user-visible behavior, without exposing internal storage backend names.
+- Kept downloads started by older versions on the legacy IndexedDB finalization path instead of attempting an unsafe migration.
+- Treated conservative storage estimates as informational when unlimited storage permission makes the extension quota-exempt.
+
+### Security
+
+- Updated vulnerable and outdated dependencies and added a repeatable security gate combining `pnpm audit` with verification of locally patched compatibility dependencies.
+- Tightened the Firefox content security policy by removing `unsafe-eval`.
+
+### Compatibility
+
+- Requires Firefox 128 or newer and Chromium 111 or newer.
+- Preserves existing settings and uses MP4 when the new output-format setting is absent.
+- Keeps downloads started by an older extension version readable without migrating them. If legacy finalization runs out of memory, delete the job and download it again.
+- Adds no new extension permissions.
 
 ### Testing
 
-- Added OPFS fragment routing/overwrite/quota tests, seekable-output device tests, worker queue/coalescing/cancellation tests, and artifact lease tests.
-- Added persistence-policy and quota-exempt preflight coverage.
+- Added coverage for disk-backed fragment routing, overwrite and quota behavior, seekable mux output, worker queuing and cancellation, artifact lifetime, persistence policy, UI workflows, and local browser E2E.
+- `pnpm run security:audit`
+- `pnpm run typecheck`
 - `pnpm test`
-- `pnpm run build:mv2`
-- `pnpm run build:mv3`
+- `pnpm run build:all-variants`
+- `pnpm exec web-ext lint --source-dir dist/mv2`
+- `pnpm test:e2e:local`
 
 ## 5.4.4
 

--- a/FOR-DEAR-TESTERS.md
+++ b/FOR-DEAR-TESTERS.md
@@ -4,12 +4,12 @@ A short guide for Mozilla/Chromium QA to build and exercise the extension locall
 
 ## Prerequisites
 
-- Firefox 115+ or Chromium 109+
-- Node.js 20+ (ships with Corepack)
+- Firefox 128+ or Chromium 111+
+- Node.js 22.12+ (ships with Corepack)
 - Enable pnpm via Corepack:
   ```bash
   corepack enable
-  corepack prepare pnpm@10.11.0 --activate
+  corepack prepare pnpm@10.34.4 --activate
   ```
 - From repo root: `pnpm install --frozen-lockfile`
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ cd hls-downloader
 
 # install the pinned pnpm version
 corepack enable
-corepack prepare pnpm@10.11.0 --activate
+corepack prepare pnpm@10.34.4 --activate
 
 pnpm install --frozen-lockfile
 pnpm run build    # outputs → ./dist/, extension-chrome.zip, extension-firefox.xpi
@@ -178,7 +178,7 @@ For Firefox Add-ons source review, use the exact reproduction steps in
 `source-code.zip`; `pnpm run publish:firefox` creates a fresh source archive from
 the committed release revision.
 
-> Tip: If pnpm is missing, run `corepack enable && corepack prepare pnpm@10.11.0 --activate` to match the locked toolchain.
+> Tip: If pnpm is missing, run `corepack enable && corepack prepare pnpm@10.34.4 --activate` to match the locked toolchain.
 
 Run tests & generate coverage badge:
 

--- a/src/assets/manifest.chrome.json
+++ b/src/assets/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "HLS Downloader",
   "description": "HTTP Live Stream downloader",
-  "version": "5.4.4",
+  "version": "5.5.0",
   "minimum_chrome_version": "111",
   "action": {
     "default_popup": "popup.html",

--- a/src/assets/manifest.json
+++ b/src/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "HLS Downloader",
   "description": "HTTP Live Stream downloader",
-  "version": "5.4.4",
+  "version": "5.5.0",
   "browser_action": {
     "default_popup": "popup.html",
     "default_title": "HLS Downloader"


### PR DESCRIPTION
## Summary

- prepare the extension manifests and changelog for the stable `v5.5.0` release
- document the disk-backed download pipeline, MP4/MKV selection, popup polish, security hardening, and compatibility requirements
- align contributor and source-review instructions with Node.js 22.12+, pnpm 10.34.4, Firefox 128+, and Chromium 111+

## Why

Five commits have landed since `v5.4.4`, including user-facing features and a substantial large-download reliability change. This PR makes that release range publishable and gives GitHub users a complete, user-oriented changelog.

## Validation

- `pnpm run security:audit`
- `pnpm run typecheck`
- `pnpm test` — 272 tests passed
- `pnpm run build:all-variants`
- `pnpm exec web-ext lint --source-dir dist/mv2` — 0 errors, 6 warnings
- `pnpm test:e2e:local` — Chromium MV3 HLS download completed as Matroska with no runtime exceptions
- all six release archives passed ZIP integrity and manifest/permission/CSP inspection
- representative popup stories passed visual, overflow, interaction, and dark-theme checks at 520×700
- Firefox MV2 installed successfully as a temporary add-on in a fresh headless profile

## Testing limitation

An interactive Firefox download could not be automated in this environment. The Firefox package passed lint, unit/integration coverage, archive inspection, and temporary-install smoke testing.

## Release scope

GitHub release only. This PR does not publish to AMO or the Chrome Web Store. Dependabot PRs #544–#546 remain outside the release.
